### PR TITLE
[DOCS] Resolve backlog decisions for Features (i18n/stats/SEO)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,9 +6,9 @@
 ## Features
 
 - [ ] 다국어 지원(i18n) — 한국어+영어만. 라이브러리 없이 `ERROR_MESSAGES`를 `{ ko, en }` 딕셔너리로 확장, locale은 `navigator.language` 기본 + 수동 토글, 의존성 0. Effort L.
-- [ ] URL 유효기간 설정 — localStorage에 생성 시간 저장, 만료 시 오류(no-server). Effort L.
-- [ ] 통계 수집 — 인바운드(축약 주소 접속) 시점에만 Umami로 short code + timestamp 전송(최소 데이터, PII 없음). 앱은 정적 유지, CSP `connect-src`/`script-src`에 Umami 호스트 화이트리스트 추가 선행. Effort L.
-- [ ] SEO — 최소 범위: description 메타 + OG/twitter 카드(og:title/description/type/image) + 정적 OG 이미지 1장. sitemap·structured data 제외(내부 도구). Effort S.
+- [ ] URL 유효기간 설정 — 만료 시각을 short code 자체에 인코딩(Sqids 배열에 expiry 추가). localStorage는 origin·브라우저 스코프라 공유 URL(타 기기/브라우저 수신자)에서 만료 검증 불가하므로 배제. 기존 코드 하위호환(만료 없는 레거시 코드) 및 code 길이 증가 고려 필요. Effort L.
+- [ ] 통계 수집 — 인바운드(축약 주소 접속) 시점에만 Umami로 short code + timestamp 전송(최소 데이터, PII 없음). 리다이렉트 직전 `navigator.sendBeacon`/`keepalive`로 전송 보장(즉시 이탈 시 유실 방지). 앱은 정적 유지, CSP `connect-src`/`script-src`에 Umami 호스트 화이트리스트 추가 선행. Effort L.
+- [ ] SEO — 최소 범위: description 메타 + OG/twitter 카드(og:title/description/type/image) + 정적 OG 이미지 1장(사이트 전역 고정). 크롤러가 JS 미실행이라 단축 URL별 동적 OG는 불가 — 전역 정적 카드로 한정. sitemap·structured data 제외(내부 도구). Effort S.
 
 ---
 

--- a/backlog.md
+++ b/backlog.md
@@ -5,10 +5,10 @@
 
 ## Features
 
-- [ ] 다국어 지원(i18n) — 영어/중국어/일본어, 모든 사용자 메시지 국제화. Effort L. (결정 필요: 필수 여부·라이브러리 — 미해결 질문 3)
-- [ ] URL 유효기간 설정 — localStorage 또는 서버에 생성 시간 저장, 만료 시 오류. Effort L.
-- [ ] 통계 수집 — 단축 URL 클릭/리다이렉트 추적, 프라이버시 고려 최소 데이터. Effort L. (결정 필요: 서버 vs 로컬 — 미해결 질문 4)
-- [ ] SEO — 메타 태그 / OG 이미지 추가. (결정 필요: 미해결 질문 5)
+- [ ] 다국어 지원(i18n) — 한국어+영어만. 라이브러리 없이 `ERROR_MESSAGES`를 `{ ko, en }` 딕셔너리로 확장, locale은 `navigator.language` 기본 + 수동 토글, 의존성 0. Effort L.
+- [ ] URL 유효기간 설정 — localStorage에 생성 시간 저장, 만료 시 오류(no-server). Effort L.
+- [ ] 통계 수집 — 인바운드(축약 주소 접속) 시점에만 Umami로 short code + timestamp 전송(최소 데이터, PII 없음). 앱은 정적 유지, CSP `connect-src`/`script-src`에 Umami 호스트 화이트리스트 추가 선행. Effort L.
+- [ ] SEO — 최소 범위: description 메타 + OG/twitter 카드(og:title/description/type/image) + 정적 OG 이미지 1장. sitemap·structured data 제외(내부 도구). Effort S.
 
 ---
 
@@ -16,6 +16,6 @@
 
 1. ~~**GitHub Pages 배포**: 기본 도메인 vs 커스텀 도메인?~~ — 해결(2026-07-19): GH Pages 미사용. 프로덕션은 KNUE 서버 `www.knue.ac.kr/s/`, CI가 `dist-build` 아티팩트 자동 빌드(`base:'./'`), `/s/` 배포는 수동.
 2. ~~**모니터링**: Sentry 연동 vs 로컬 로깅 유지?~~ — 해결(2026-07-19): 경량 로컬 로깅 유지. 중앙 `logError` 로거(`src/errorLogger.ts`)로 통합, 외부 SDK 미도입(no-server·번들 최적화 유지). 향후 모니터링 교체 시 `logError` 단일 seam.
-3. **다국어**: 필수인가? i18n 라이브러리 선택?
-4. **통계 데이터**: 서버 저장 vs 클라이언트 로컬스토리지?
-5. **SEO**: 메타 태그/OG 이미지 필요?
+3. ~~**다국어**: 필수인가? i18n 라이브러리 선택?~~ — 해결(2026-07-19): 한국어+영어만. 라이브러리 미도입, `ERROR_MESSAGES`를 `{ ko, en }`로 확장 + `navigator.language` 기본/수동 토글, 의존성 0.
+4. ~~**통계 데이터**: 서버 저장 vs 클라이언트 로컬스토리지?~~ — 해결(2026-07-19): 인바운드 접속 시점에만 Umami로 최소 데이터(code+timestamp, PII 없음) 전송. 앱 정적 유지, no-server 원칙에 "외부 수집 1곳(Umami)" 예외. CSP 화이트리스트 추가 선행.
+5. ~~**SEO**: 메타 태그/OG 이미지 필요?~~ — 해결(2026-07-19): 최소 범위(description + OG/twitter 카드 + 정적 OG 이미지 1장)만. 공유 미리보기 개선 목적, 검색 랭킹용 machinery 제외.


### PR DESCRIPTION
Resolve 미해결 질문 3/4/5 blocking the Features group; make all four
items actionable:
- i18n: Korean+English only, no library (extend ERROR_MESSAGES to {ko,en})
- stats: Umami beacon on inbound hit only (code+timestamp, no PII)
- SEO: minimal scope (description + OG/twitter meta + one OG image)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>